### PR TITLE
feat(scion-rcp-plugin): add Eclipse IDE settings and targetplatform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,9 @@
 **/.idea/
-**/.project
-**/.classpath
 **/.launch
-**/.settings/
 
 **/target/
 **/bin/
 **/*.log
-**/.settings/
 **/.m2/
 **/.metadata/
 **/build.xml

--- a/.project
+++ b/.project
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>scion-rcp</name>
+	<comment></comment>
+	<projects>
+	</projects>
+</projectDescription>

--- a/ch.sbb.scion.rcp.microfrontend.app.demo/.classpath
+++ b/ch.sbb.scion.rcp.microfrontend.app.demo/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/ch.sbb.scion.rcp.microfrontend.app.demo/.project
+++ b/ch.sbb.scion.rcp.microfrontend.app.demo/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>ch.sbb.scion.rcp.microfrontend.app.demo</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/ch.sbb.scion.rcp.microfrontend.app.demo/.settings/org.eclipse.jdt.core.prefs
+++ b/ch.sbb.scion.rcp.microfrontend.app.demo/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,15 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.methodParameters=do not generate
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=17

--- a/ch.sbb.scion.rcp.microfrontend.targetplatform/.project
+++ b/ch.sbb.scion.rcp.microfrontend.targetplatform/.project
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>ch.sbb.scion.rcp.microfrontend.targetplatform</name>
+	<comment></comment>
+	<projects>
+	</projects>
+</projectDescription>

--- a/ch.sbb.scion.rcp.microfrontend.targetplatform/ch.sbb.scion.rcp.microfrontend.targetplatform.target
+++ b/ch.sbb.scion.rcp.microfrontend.targetplatform/ch.sbb.scion.rcp.microfrontend.targetplatform.target
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target name="scion">
+	<locations>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/releases/2022-03"/>
+			<unit id="org.eclipse.e4.rcp.feature.group" version="4.23.0.v20220308-0630"/>
+			<unit id="com.google.gson" version="2.8.9.v20220111-1409"/>
+		</location>
+	</locations>
+</target>

--- a/ch.sbb.scion.rcp.microfrontend/.classpath
+++ b/ch.sbb.scion.rcp.microfrontend/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/ch.sbb.scion.rcp.microfrontend/.project
+++ b/ch.sbb.scion.rcp.microfrontend/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>ch.sbb.scion.rcp.microfrontend</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/ch.sbb.scion.rcp.microfrontend/.settings/org.eclipse.jdt.core.prefs
+++ b/ch.sbb.scion.rcp.microfrontend/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,15 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.methodParameters=do not generate
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=17

--- a/ch.sbb.scion.rcp.microfrontend/META-INF/MANIFEST.MF
+++ b/ch.sbb.scion.rcp.microfrontend/META-INF/MANIFEST.MF
@@ -26,4 +26,5 @@ Service-Component: OSGI-INF/ch.sbb.scion.rcp.microfrontend.MicrofrontendPlatform
  OSGI-INF/ch.sbb.scion.rcp.microfrontend.host.MicrofrontendPlatformRcpHost.xml,
  OSGI-INF/ch.sbb.scion.rcp.microfrontend.keyboard.KeyboardEventMapper.xml
 Import-Package: javax.annotation,
- javax.inject;resolution:=optional
+ javax.inject;resolution:=optional,
+ org.osgi.service.component.annotations

--- a/ch.sbb.scion.rcp.microfrontend/build.properties
+++ b/ch.sbb.scion.rcp.microfrontend/build.properties
@@ -1,5 +1,4 @@
-source.. = src/,\
-           js/
+source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
                .,\

--- a/scion-rcp-microfrontend-client-demo-app/.project
+++ b/scion-rcp-microfrontend-client-demo-app/.project
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>scion-rcp-microfrontend-client-demo-app</name>
+	<comment></comment>
+	<projects>
+	</projects>
+</projectDescription>

--- a/scion-rcp-microfrontend-host-dependency-bundler/.project
+++ b/scion-rcp-microfrontend-host-dependency-bundler/.project
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>scion-rcp-microfrontend-host-dependency-bundler</name>
+	<comment></comment>
+	<projects>
+	</projects>
+</projectDescription>


### PR DESCRIPTION
The Eclipse IDE settings allow contributors to directly start developing
in the IDE without manual setups of the projects.

Fixes #6