### PR TITLE
Issue/fixes

### DIFF
--- a/ch.sbb.scion.rcp.microfrontend/src/ch/sbb/scion/rcp/microfrontend/SciManifestService.java
+++ b/ch.sbb.scion.rcp.microfrontend/src/ch/sbb/scion/rcp/microfrontend/SciManifestService.java
@@ -30,6 +30,8 @@ import ch.sbb.scion.rcp.microfrontend.script.Scripts.Refs;
 @Component(service = SciManifestService.class)
 public class SciManifestService {
 
+  private CompletableFuture<List<Application>> applications;
+
   @Reference
   private MicrofrontendPlatformRcpHost microfrontendPlatformRcpHost;
 
@@ -37,19 +39,20 @@ public class SciManifestService {
    * @see https://scion-microfrontend-platform-api.vercel.app/classes/ManifestService.html#applications
    */
   public CompletableFuture<List<Application>> getApplications() {
-    var applications = new CompletableFuture<List<Application>>();
-    new JavaCallback(microfrontendPlatformRcpHost.whenHostBrowser, args -> {
-      applications.complete(GsonFactory.create().fromJson((String) args[0], new ParameterizedType(List.class, Application.class)));
-    })
-        .installOnce()
-        .thenAccept(callback -> {
-          new JavaScriptExecutor(microfrontendPlatformRcpHost.hostBrowser, Resources.readString("js/sci-manifest-service/lookup-applications.js"))
-              .replacePlaceholder("callback", callback.name)
-              .replacePlaceholder("refs.ManifestService", Refs.ManifestService)
-              .replacePlaceholder("helpers.toJson", Helpers.toJson)
-              .execute();
-        });
-
+    if (applications == null) {
+      applications = new CompletableFuture<List<Application>>();
+      new JavaCallback(microfrontendPlatformRcpHost.whenHostBrowser, args -> {
+        applications.complete(GsonFactory.create().fromJson((String) args[0], new ParameterizedType(List.class, Application.class)));
+      })
+          .installOnce()
+          .thenAccept(callback -> {
+            new JavaScriptExecutor(microfrontendPlatformRcpHost.hostBrowser, Resources.readString("js/sci-manifest-service/lookup-applications.js"))
+                .replacePlaceholder("callback", callback.name)
+                .replacePlaceholder("refs.ManifestService", Refs.ManifestService)
+                .replacePlaceholder("helpers.toJson", Helpers.toJson)
+                .execute();
+          });
+    }
     return applications;
   }
 

--- a/ch.sbb.scion.rcp.microfrontend/src/ch/sbb/scion/rcp/microfrontend/browser/JavaCallback.java
+++ b/ch.sbb.scion.rcp.microfrontend/src/ch/sbb/scion/rcp/microfrontend/browser/JavaCallback.java
@@ -67,15 +67,12 @@ public class JavaCallback implements IDisposable {
           browserFunction = new BrowserFunction(browser, name) {
             @Override
             public Boolean function(Object[] arguments) {
-              try {
-                // TODO [ISW] Otherwise creating another browser would block if created within a browser function
-                browser.getDisplay().asyncExec(() -> callback.accept(arguments));   
+              if (once) {
+                dispose();
               }
-              finally {
-                if (once) {
-                  dispose();
-                }
-              }
+              // Invoke the callback asynchronously to first complete the invocation of this browser function.
+              // Otherwise, creating a new {@link Browser} instance in the callback would lead to a deadlock.
+              browser.getDisplay().asyncExec(() -> callback.accept(arguments));
               return true;
             }
           };

--- a/ch.sbb.scion.rcp.workbench/src/ch/sbb/scion/rcp/workbench/view/CompletableFutures.java
+++ b/ch.sbb.scion.rcp.workbench/src/ch/sbb/scion/rcp/workbench/view/CompletableFutures.java
@@ -1,0 +1,32 @@
+package ch.sbb.scion.rcp.workbench.view;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.swt.widgets.Display;
+
+public class CompletableFutures {
+
+  private CompletableFutures() {
+  }
+
+  /**
+   * Blocks until the given {@link CompletableFuture} has completed and returns its result.
+   * 
+   * If invoked from the UI thread, continuously dispatches pending work from the operating system's event queue,
+   * supporting awaiting a future in the UI thread even if the future is also executing in the UI thread. Otherwise,
+   * a deadlock would occur since blocking the UI thread for the future to complete would prevent the future from
+   * continuing execution.
+   */
+  public static <T> T await(final CompletableFuture<T> completableFuture) {
+    // If not invoked from the UI thread, simply await the future.
+    if (Display.getCurrent().getThread() != Thread.currentThread()) {
+      return completableFuture.join();
+    }
+
+    // Continuously dispatch pending work from the operating system's event queue while waiting for the future to complete.
+    while (!completableFuture.isDone()) {
+      Display.getCurrent().readAndDispatch();
+    }
+    return completableFuture.join();
+  }
+}

--- a/ch.sbb.scion.rcp.workbench/src/ch/sbb/scion/rcp/workbench/view/MicrofrontendViewEditorPart.java
+++ b/ch.sbb.scion.rcp.workbench/src/ch/sbb/scion/rcp/workbench/view/MicrofrontendViewEditorPart.java
@@ -116,15 +116,14 @@ public class MicrofrontendViewEditorPart extends EditorPart implements IReusable
     }
 
     // Load the microfrontend
-    applications.thenAccept(applications -> {
-      var appSymbolicName = capability.metadata.appSymbolicName;
-      var path = (String) capability.properties.get("path");
-      outletRouter.navigate(path, new NavigationOptions()
-          .outlet(getSciViewId())
-          .relativeTo(applications.get(appSymbolicName).baseUrl)
-          .params(params)
-          .pushStateToSessionHistoryStack(false));
-    });
+    var applications = CompletableFutures.await(this.applications);
+    var appSymbolicName = capability.metadata.appSymbolicName;
+    var path = (String) capability.properties.get("path");
+    outletRouter.navigate(path, new NavigationOptions()
+        .outlet(getSciViewId())
+        .relativeTo(applications.get(appSymbolicName).baseUrl)
+        .params(params)
+        .pushStateToSessionHistoryStack(false));
   }
 
   @Override

--- a/ch.sbb.scion.rcp.workbench/src/ch/sbb/scion/rcp/workbench/view/MicrofrontendViewEditorPart.java
+++ b/ch.sbb.scion.rcp.workbench/src/ch/sbb/scion/rcp/workbench/view/MicrofrontendViewEditorPart.java
@@ -64,7 +64,6 @@ public class MicrofrontendViewEditorPart extends EditorPart implements IReusable
 
   @Override
   public void init(final IEditorSite site, final IEditorInput input) throws PartInitException {
-    // TODO [ISW] Move to separate service and fetch applications once.
     applications = manifestService.getApplications().thenApply(applications -> {
       return applications.stream().collect(Collectors.toMap(a -> a.symbolicName, Function.identity()));
     });


### PR DESCRIPTION
- fix(scion-rcp-microfrontend-plugin): support creating new browser in browser function
- fix(scion-rcp-workbench-plugin): load applications only once
- feat(scion-rcp-workbench-plugin): support synchronous waiting for `CompletableFuture` from the UI thread for better readability
- feat(scion-rcp-workbench-plugin): signal microfrontend when about to be unloaded to clean up resources