### PR TITLE
Support back navigation in microfrontends

### DIFF
--- a/ch.sbb.scion.rcp.workbench/src/ch/sbb/scion/rcp/workbench/view/MicrofrontendViewEditorPart.java
+++ b/ch.sbb.scion.rcp.workbench/src/ch/sbb/scion/rcp/workbench/view/MicrofrontendViewEditorPart.java
@@ -117,7 +117,7 @@ public class MicrofrontendViewEditorPart extends EditorPart implements IReusable
     var appSymbolicName = capability.metadata.appSymbolicName;
     var path = (String) capability.properties.get("path");
     outletRouter.navigate(path, new NavigationOptions().outlet(getSciViewId()).relativeTo(applications.get(appSymbolicName).baseUrl)
-        .params(params).pushStateToSessionHistoryStack(Boolean.FALSE));
+        .params(params).pushStateToSessionHistoryStack(Boolean.TRUE));
   }
 
   @Override


### PR DESCRIPTION
* In MicrofrontendViewEditorPart.setInput(...) set pushStateToSessionHistoryStack to true  to enable back navigation from the SSP to the Portal