### PR TITLE
feat(scion-rcp-workbench-plugin): disable back navigation

### DIFF
--- a/ch.sbb.scion.rcp.workbench/src/ch/sbb/scion/rcp/workbench/view/MicrofrontendViewEditorPart.java
+++ b/ch.sbb.scion.rcp.workbench/src/ch/sbb/scion/rcp/workbench/view/MicrofrontendViewEditorPart.java
@@ -117,7 +117,7 @@ public class MicrofrontendViewEditorPart extends EditorPart implements IReusable
     var appSymbolicName = capability.metadata().appSymbolicName();
     var path = (String) capability.properties().get("path");
     outletRouter.navigate(path, NavigationOptions.builder().outlet(getSciViewId()).relativeTo(applications.get(appSymbolicName).baseUrl())
-        .params(params).pushStateToSessionHistoryStack(Boolean.TRUE).build());
+        .params(params).pushStateToSessionHistoryStack(Boolean.FALSE).build());
   }
 
   @Override


### PR DESCRIPTION
Disables back navigation in microfrontends. 

The https://flow.sbb.ch/browse/RCSPF-131150 bug can be reproduced only after back navigation, so disabling the back navigation fixes the bug. 