### PR TITLE
fix(scion-rcp): downgrade eclipse release and ensure packaging type jar

### DIFF
--- a/.github/scripts/replace-packaging.sh
+++ b/.github/scripts/replace-packaging.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+pom_file="$1"
+
+if [[ -f $pom_file ]] ; then
+  echo "Attempting to replace eclipse-packaging with jar packaging in $pom_file"
+  sed -i 's#<packaging>eclipse-plugin</packaging>#<packaging>jar</packaging>#' "$pom_file"
+fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- This CHANGELOG file.
+
+### Changed
+
+- Downgrade Eclipse release and Eclipse Orbit release from 2023-03 to 2022-03.
+- Set packaging type of Eclipse plugins to jar in flattened POM.
+
+## [0.0.1] - 2023-05-17
+
+### Added
+
+- The Scion RCP microfrontend bundle.
+- The Scion RCP microfrontend test fragment.
+- The Scion RCP workbench bundle.
+- The Scion RCP workbench test fragment.
+- The target platform bundle.
+- The e3 demo app bundle.
+- The e3 demo app product bundle.
+- The e3 demo app test bundle.
+- The (e4) demo app bundle.
+- The (e4) demo app product bundle.
+- The main feature bundle, to allow feature-based products.
+- The test feature bundle.
+- The Eclipse setup bundle.
+- The code coverage bundle.
+- The SWT bot feature bundle.
+- The client demo app, a TypeScript demo microfrontend app.
+- The Scion microfrontend host dependency bundler project, a utility to transpile the Scion Microfrontend Platform into JavaScript.
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- (c) Copyright by SBB AG, 2019 - Alle Rechte vorbehalten -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>ch.sbb.scion</groupId>
@@ -17,14 +19,32 @@
 
 	<developers>
 		<developer>
+			<name>Marc Hoffmann</name>
+			<email>marc.hoffmann@sbb.ch</email>
+			<organization>Swiss Federal Railways (SBB)</organization>
+			<organizationUrl>https://www.sbb.ch</organizationUrl>
+		</developer>
+		<developer>
 			<name>Gilles Iachelini</name>
 			<email>gilles.iachelini@sbb.ch</email>
 			<organization>Swiss Federal Railways (SBB)</organization>
 			<organizationUrl>https://www.sbb.ch</organizationUrl>
 		</developer>
 		<developer>
+			<name>István Lőrincz</name>
+			<email>istvan.lorincz@sbb.ch</email>
+			<organization>Swiss Federal Railways (SBB)</organization>
+			<organizationUrl>https://www.sbb.ch</organizationUrl>
+		</developer>
+		<developer>
 			<name>Adrian Ruckli</name>
 			<email>adrian.ruckli@sbb.ch</email>
+			<organization>Swiss Federal Railways (SBB)</organization>
+			<organizationUrl>https://www.sbb.ch</organizationUrl>
+		</developer>
+		<developer>
+			<name>Daniel Wiehl</name>
+			<email>daniel.wiehl@sbb.ch</email>
 			<organization>Swiss Federal Railways (SBB)</organization>
 			<organizationUrl>https://www.sbb.ch</organizationUrl>
 		</developer>
@@ -52,12 +72,16 @@
 		<release-plugin.version>3.0.0</release-plugin.version>
 		<deploy-plugin.version>3.1.1</deploy-plugin.version>
 		<javadoc-plugin.version>2.9.1</javadoc-plugin.version>
+		<exec-plugin.version>3.1.0</exec-plugin.version>
 
-		<eclipse.release>2023-03</eclipse.release>
-		<eclipse.orbit.release>R20230302014618</eclipse.orbit.release>
+		<eclipse.release>2022-03</eclipse.release>
+		<eclipse.orbit.release>R20220302172233</eclipse.orbit.release>
 
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		
+		<!-- Scripts are executed in child modules only: -->
+		<scripts.location>${project.parent.basedir}/.github/scripts</scripts.location>
 	</properties>
 
 	<repositories>
@@ -290,6 +314,19 @@
 				</configuration>
 			</plugin>
 
+			<plugin>
+				<!-- Do not attempt to replace packaging in parent pom! -->
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<inherited>false</inherited>
+				<executions>
+					<execution>
+						<id>exec-exec</id>
+						<phase>none</phase>
+					</execution>
+				</executions>
+			</plugin>
+
 		</plugins>
 
 		<pluginManagement>
@@ -325,6 +362,33 @@
 						<flattenMode>ossrh</flattenMode>
 					</configuration>
 				</plugin>
+
+				<plugin>
+					<!-- Replace packaging type 'eclipse-plugin', that is required by the 
+						tycho build, with packaging type 'jar' in the flattened POMs. Otherwise we 
+						cannot use the released artifacts as standard Maven dependencies. -->
+					<groupId>org.codehaus.mojo</groupId>
+					<artifactId>exec-maven-plugin</artifactId>
+					<version>${exec-plugin.version}</version>
+					<executions>
+						<execution>
+							<id>exec-exec</id>
+							<!-- Bind to a phase that is after compilation but before verification. -->
+							<phase>prepare-package</phase>
+							<goals>
+								<goal>exec</goal>
+							</goals>
+						</execution>
+					</executions>
+					<configuration>
+						<executable>bash</executable>
+						<arguments>
+							<argument>${scripts.location}/replace-packaging.sh</argument>
+							<argument>${basedir}/.flattened-pom.xml</argument>
+						</arguments>
+					</configuration>
+				</plugin>
+
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-gpg-plugin</artifactId>


### PR DESCRIPTION
 * Downgrade to Eclipse release 2022-03, as we need artifacts for that release.
 * Include all contributors as developers in the POM until we have a team email.
 * Ensure packaging type jar in POMs of released artifacts. The tycho build requires packaging type eclipse-plugin, therefore, the packaging type should be adjusted in the flattened POM directly, after compilation but before any signatures or checksums were generated.