### PR TITLE
fix(scion-rcp): replace packaging type, do not close staged repo

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -83,7 +83,9 @@ mvn -B org.sonatype.plugins:nexus-staging-maven-plugin:1.6.13:deploy-staged-repo
   -DnexusUrl="https://oss.sonatype.org" \
   -DserverId="ossrh" \
   -DrepositoryDirectory=. \
-  -DstagingProfileId="$staging_profile_id"
+  -DstagingProfileId="$staging_profile_id" \
+  -DskipStagingRepositoryClose=true
+exit_if_failed "$?" "Upload staged artifacts to remote stage failed, exiting"
 echo "Returning to $work_dir"
 cd $work_dir
 

--- a/.github/scripts/replace-packaging.sh
+++ b/.github/scripts/replace-packaging.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-pom_file="$1"
-
-if [[ -f $pom_file ]] ; then
-  echo "Attempting to replace eclipse-packaging with jar packaging in $pom_file"
-  sed -i 's#<packaging>eclipse-plugin</packaging>#<packaging>jar</packaging>#' "$pom_file"
-fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Downgrade Eclipse release and Eclipse Orbit release from 2023-03 to 2022-03.
-- Set packaging type of Eclipse plugins to jar in flattened POM.
+- Replace packaging type with implied packaging type - i.e., jar - in the tycho consumer pom, which is the final pom that will be deployed.
+- Skip closing the remotely staged repository during the upload step. Recently, the connection between the Github build server and the Nexus Repository timed out while waiting for the closing result, frequently. Close the staged repository manually, directly in the Nexus Repository.
 
 ## [0.0.1] - 2023-05-17
 

--- a/pom.xml
+++ b/pom.xml
@@ -72,16 +72,12 @@
 		<release-plugin.version>3.0.0</release-plugin.version>
 		<deploy-plugin.version>3.1.1</deploy-plugin.version>
 		<javadoc-plugin.version>2.9.1</javadoc-plugin.version>
-		<exec-plugin.version>3.1.0</exec-plugin.version>
 
 		<eclipse.release>2022-03</eclipse.release>
 		<eclipse.orbit.release>R20220302172233</eclipse.orbit.release>
 
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		
-		<!-- Scripts are executed in child modules only: -->
-		<scripts.location>${project.parent.basedir}/.github/scripts</scripts.location>
 	</properties>
 
 	<repositories>
@@ -139,6 +135,7 @@
 				<version>${tycho.version}</version>
 				<configuration>
 					<strictVersions>false</strictVersions>
+					<replacePackagingType>true</replacePackagingType>
 				</configuration>
 				<executions>
 					<execution>
@@ -314,19 +311,6 @@
 				</configuration>
 			</plugin>
 
-			<plugin>
-				<!-- Do not attempt to replace packaging in parent pom! -->
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>exec-maven-plugin</artifactId>
-				<inherited>false</inherited>
-				<executions>
-					<execution>
-						<id>exec-exec</id>
-						<phase>none</phase>
-					</execution>
-				</executions>
-			</plugin>
-
 		</plugins>
 
 		<pluginManagement>
@@ -360,32 +344,6 @@
 					</executions>
 					<configuration>
 						<flattenMode>ossrh</flattenMode>
-					</configuration>
-				</plugin>
-
-				<plugin>
-					<!-- Replace packaging type 'eclipse-plugin', that is required by the 
-						tycho build, with packaging type 'jar' in the flattened POMs. Otherwise we 
-						cannot use the released artifacts as standard Maven dependencies. -->
-					<groupId>org.codehaus.mojo</groupId>
-					<artifactId>exec-maven-plugin</artifactId>
-					<version>${exec-plugin.version}</version>
-					<executions>
-						<execution>
-							<id>exec-exec</id>
-							<!-- Bind to a phase that is after compilation but before verification. -->
-							<phase>prepare-package</phase>
-							<goals>
-								<goal>exec</goal>
-							</goals>
-						</execution>
-					</executions>
-					<configuration>
-						<executable>bash</executable>
-						<arguments>
-							<argument>${scripts.location}/replace-packaging.sh</argument>
-							<argument>${basedir}/.flattened-pom.xml</argument>
-						</arguments>
 					</configuration>
 				</plugin>
 


### PR DESCRIPTION
 * The packaging type in the deployed POMs should be jar (default). Therefore, replace the packaging type in the tycho consumer POM which is the POM that will be deployed. Note, that POM is partially based on the flattened POM, however, the packaging type is not inherited.
 * Skip closing the remotely staged repository. Apparently, the network connection between the Github build server and the Nexus Repository is quite unstable. This leads to time outs while waiting for the closing result, frequently. Close the staged repository in the Nexus Repository manually.
 * Exit with error on failed staging. Currently, the release worklfow succeeds also if staging failed.