### PR TITLE
fix(scion-rcp): reduce required EE to Java 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Reduce required execution environment of the Scion RCP microfrontend and the Scion RCP workbench bundles from Java 17 to Java 11.
+
 ## [0.0.2] - 2023-05-23
 
 ### Added

--- a/ch.sbb.scion.rcp.microfrontend/.classpath
+++ b/ch.sbb.scion.rcp.microfrontend/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/ch.sbb.scion.rcp.microfrontend/META-INF/MANIFEST.MF
+++ b/ch.sbb.scion.rcp.microfrontend/META-INF/MANIFEST.MF
@@ -11,7 +11,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.e4.core.contexts,
  com.google.gson,
  wrapped.org.projectlombok.lombok;resolution:=optional
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: rcp-microfrontend
 Bundle-ActivationPolicy: lazy
 Export-Package: ch.sbb.scion.rcp.microfrontend,

--- a/ch.sbb.scion.rcp.workbench/.classpath
+++ b/ch.sbb.scion.rcp.workbench/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/ch.sbb.scion.rcp.workbench/META-INF/MANIFEST.MF
+++ b/ch.sbb.scion.rcp.workbench/META-INF/MANIFEST.MF
@@ -13,7 +13,7 @@ Require-Bundle: org.eclipse.ui,
  com.google.gson,
  org.eclipse.jface,
  wrapped.org.projectlombok.lombok;resolution:=optional
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: rcp-workbench
 Bundle-ActivationPolicy: lazy
 Import-Package: javax.annotation,


### PR DESCRIPTION
 * Need artifacts that have Java 11 as required execution environment. Only adjust the Manifest of the two released modules.