### PR TITLE
feat(scion-rcp): make all-args ctors of model classes public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Make all argument constructors of model classes public. This change allows to extend these classes, which was effectively inhibited previously - there is no decision against allowing the extension of model classes, currently.
+
 ## [0.0.5] - 2023-06-19
 
 ### Changed

--- a/ch.sbb.scion.rcp.microfrontend/src/ch/sbb/scion/rcp/microfrontend/model/Application.java
+++ b/ch.sbb.scion.rcp.microfrontend/src/ch/sbb/scion/rcp/microfrontend/model/Application.java
@@ -1,6 +1,5 @@
 package ch.sbb.scion.rcp.microfrontend.model;
 
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,7 +13,7 @@ import lombok.experimental.Accessors;
 @Accessors(fluent = true)
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 @Builder
 @ToString
 public class Application {

--- a/ch.sbb.scion.rcp.microfrontend/src/ch/sbb/scion/rcp/microfrontend/model/ApplicationConfig.java
+++ b/ch.sbb.scion.rcp.microfrontend/src/ch/sbb/scion/rcp/microfrontend/model/ApplicationConfig.java
@@ -1,6 +1,5 @@
 package ch.sbb.scion.rcp.microfrontend.model;
 
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,7 +13,7 @@ import lombok.experimental.Accessors;
 @Accessors(fluent = true)
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 @Builder
 @ToString
 public class ApplicationConfig {

--- a/ch.sbb.scion.rcp.microfrontend/src/ch/sbb/scion/rcp/microfrontend/model/Capability.java
+++ b/ch.sbb.scion.rcp.microfrontend/src/ch/sbb/scion/rcp/microfrontend/model/Capability.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import com.google.gson.annotations.SerializedName;
 
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,7 +17,7 @@ import lombok.experimental.Accessors;
 @Accessors(fluent = true)
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 @Builder
 @ToString
 public class Capability {

--- a/ch.sbb.scion.rcp.microfrontend/src/ch/sbb/scion/rcp/microfrontend/model/HostConfig.java
+++ b/ch.sbb.scion.rcp.microfrontend/src/ch/sbb/scion/rcp/microfrontend/model/HostConfig.java
@@ -1,6 +1,5 @@
 package ch.sbb.scion.rcp.microfrontend.model;
 
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,7 +13,7 @@ import lombok.experimental.Accessors;
 @Accessors(fluent = true)
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 @Builder
 @ToString
 public class HostConfig {

--- a/ch.sbb.scion.rcp.microfrontend/src/ch/sbb/scion/rcp/microfrontend/model/Intent.java
+++ b/ch.sbb.scion.rcp.microfrontend/src/ch/sbb/scion/rcp/microfrontend/model/Intent.java
@@ -2,7 +2,6 @@ package ch.sbb.scion.rcp.microfrontend.model;
 
 import java.util.Map;
 
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,7 +15,7 @@ import lombok.experimental.Accessors;
 @Accessors(fluent = true)
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 @Builder
 @ToString
 public class Intent {

--- a/ch.sbb.scion.rcp.microfrontend/src/ch/sbb/scion/rcp/microfrontend/model/IntentSelector.java
+++ b/ch.sbb.scion.rcp.microfrontend/src/ch/sbb/scion/rcp/microfrontend/model/IntentSelector.java
@@ -1,6 +1,5 @@
 package ch.sbb.scion.rcp.microfrontend.model;
 
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,7 +13,7 @@ import lombok.experimental.Accessors;
 @Accessors(fluent = true)
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 @Builder
 @ToString
 public class IntentSelector {

--- a/ch.sbb.scion.rcp.microfrontend/src/ch/sbb/scion/rcp/microfrontend/model/Intention.java
+++ b/ch.sbb.scion.rcp.microfrontend/src/ch/sbb/scion/rcp/microfrontend/model/Intention.java
@@ -1,6 +1,5 @@
 package ch.sbb.scion.rcp.microfrontend.model;
 
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,7 +13,7 @@ import lombok.experimental.Accessors;
 @Accessors(fluent = true)
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 @Builder
 @ToString
 public class Intention {

--- a/ch.sbb.scion.rcp.microfrontend/src/ch/sbb/scion/rcp/microfrontend/model/Manifest.java
+++ b/ch.sbb.scion.rcp.microfrontend/src/ch/sbb/scion/rcp/microfrontend/model/Manifest.java
@@ -2,7 +2,6 @@ package ch.sbb.scion.rcp.microfrontend.model;
 
 import java.util.List;
 
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,7 +15,7 @@ import lombok.experimental.Accessors;
 @Accessors(fluent = true)
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 @Builder
 @ToString
 public class Manifest {

--- a/ch.sbb.scion.rcp.microfrontend/src/ch/sbb/scion/rcp/microfrontend/model/ManifestObjectFilter.java
+++ b/ch.sbb.scion.rcp.microfrontend/src/ch/sbb/scion/rcp/microfrontend/model/ManifestObjectFilter.java
@@ -1,6 +1,5 @@
 package ch.sbb.scion.rcp.microfrontend.model;
 
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,7 +13,7 @@ import lombok.experimental.Accessors;
 @Accessors(fluent = true)
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 @Builder
 @ToString
 public class ManifestObjectFilter {

--- a/ch.sbb.scion.rcp.microfrontend/src/ch/sbb/scion/rcp/microfrontend/model/MicrofrontendPlatformConfig.java
+++ b/ch.sbb.scion.rcp.microfrontend/src/ch/sbb/scion/rcp/microfrontend/model/MicrofrontendPlatformConfig.java
@@ -2,7 +2,6 @@ package ch.sbb.scion.rcp.microfrontend.model;
 
 import java.util.List;
 
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,7 +16,7 @@ import lombok.experimental.Accessors;
 @Accessors(fluent = true)
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 @Builder
 @ToString
 public class MicrofrontendPlatformConfig {

--- a/ch.sbb.scion.rcp.microfrontend/src/ch/sbb/scion/rcp/microfrontend/model/NavigationOptions.java
+++ b/ch.sbb.scion.rcp.microfrontend/src/ch/sbb/scion/rcp/microfrontend/model/NavigationOptions.java
@@ -2,7 +2,6 @@ package ch.sbb.scion.rcp.microfrontend.model;
 
 import java.util.Map;
 
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,7 +15,7 @@ import lombok.experimental.Accessors;
 @Accessors(fluent = true)
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 @Builder
 @ToString
 public class NavigationOptions {


### PR DESCRIPTION
 * Setting the visibility of the all-args ctor of the model classes to private was short-sighted and poorly motivated. It effectively made it impossible to extend any of these classes. Currently, there is no intention to prohibit extension, hence these ctors should be public - otherwise rather mark the classes as final.